### PR TITLE
Replace fat arrow with function syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function checkType (fodselsnummer) {
   return parseInt(fodselsnummer[0], 10) > 3 ? 'D' : 'F'
 }
 
-module.exports = (fodselsnummer, type) => {
+module.exports = function (fodselsnummer, type) {
   if (fodselsnummer.length !== 11) {
     throw new Error('Too short. Expected length of 11.')
   }


### PR DESCRIPTION
This commit removes usage of fat arrow in index.js as it requires
transpilation not to crash in IE11 >=.

fixes #52 